### PR TITLE
Remove re init of route if route was valid

### DIFF
--- a/tonic/handler.go
+++ b/tonic/handler.go
@@ -54,7 +54,6 @@ func Handler(h interface{}, status int, options ...func(*Route)) gin.HandlerFunc
 			opt(r)
 		}
 		if ok {
-			r := &Route{}
 			r.defaultStatusCode = status
 			r.handler = hv
 			r.handlerType = ht


### PR DESCRIPTION
Not sure why this happens on an check if the route has a standard binding. I removed it and fixed the setting of the route.